### PR TITLE
Relax dependency version constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        "requests==2.22.0",
-        "pyfunctional==1.3.0"
+        "requests>=2.22.0",
+        "pyfunctional>=1.3.0"
     ]
 )


### PR DESCRIPTION
This library is used by home assistant integrations. The strict version requirement conflicts with ongoing HA development.